### PR TITLE
Fix Vite paths for Electron

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-"# AutoWycena" 
+# AutoWycena
+
+## Building the React frontend
+
+The Electron application loads the compiled files from `frontend/dist`. If the
+directory does not exist, build the frontend first:
+
+```bash
+cd frontend
+npm install           # only needed once to install dependencies
+npm run build         # generates the `dist/` folder
+```
+
+After building the frontend you can start the Electron app from the repository
+root:
+
+```bash
+npm start
+```
+
+The Vite configuration uses relative asset paths (`base: './'`) so the build
+works correctly when loaded via the `file://` protocol in Electron.

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -3,6 +3,8 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  // Use relative paths so Electron can load files via the file:// protocol
+  base: './',
   build: {
     outDir: 'dist'
   }


### PR DESCRIPTION
## Summary
- document how to build the React frontend
- configure Vite to use relative paths so the Electron app can load built files

## Testing
- `npm run build` *(fails: `vite: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685bff665a40832796726f585f7706ca