### PR TITLE
Use App.jsx as React entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ npm install           # only needed once to install dependencies
 npm run build         # generates the `dist/` folder
 ```
 
+The React entry component is `App.jsx`. Ensure this file exists and is used when
+running or building the frontend.
+
 After building the frontend you can start the Electron app from the repository
 root:
 

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import App from './App';
+import App from './App.jsx';
 
 test('renders learn react link', () => {
   render(<App />);

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
-import App from './App';
+import App from './App.jsx';
 import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import App from './App';
+import App from './App.jsx';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(


### PR DESCRIPTION
## Summary
- set React entry to `App.jsx` so `npm start` loads the correct component
- mention the `App.jsx` entry file in the README

## Testing
- `npm test --prefix frontend -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c315772cc8327b7754f0911460bad