### PR TITLE
Fix settings UI and API responses

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -65,11 +65,13 @@ def create_app():
     
     @app.get("/api/openExcel1")
     def open_Excel1():
-        main.open_Excel_calculation()
+        """Open calculation Excel and return a status message."""
+        return main.open_Excel_calculation()
 
     @app.get("/api/openExcel2")
     def open_Excel2():
-        main.open_Excel_orders()
+        """Open orders Excel and return a status message."""
+        return main.open_Excel_orders()
 
     @app.get("/api/new_Excel")
     def open_Excel3():

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -171,7 +171,8 @@ export default function App() {
               <input
                 type="text"
                 id="folderPath"
-                placeholder={folderPath || 'Wklej ścieżkę...'}
+                value={folderPath}
+                placeholder="Wklej ścieżkę..."
                 onChange={e => setFolderPath(e.target.value)}
               />
               <button onClick={chooseFilePathCalculation} className="icon-button">📁</button>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -212,9 +212,15 @@ button {
     gap: 8px;
 }
 
+#settings .input-row input[type="text"] {
+    flex: 1;
+    width: auto;
+}
+
 #settings .icon-button {
     background: none;
     border: none;
+    padding: 0;
     font-size: 1.2rem;
     cursor: pointer;
     line-height: 1;


### PR DESCRIPTION
## Summary
- return status messages for the `openExcel1` and `openExcel2` API endpoints
- show selected folder in settings input
- keep settings path field on one line and remove icon button background

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `python -m py_compile backend/app.py backend/Program/main.py`

------
https://chatgpt.com/codex/tasks/task_e_685c399c2ae083278d65b8430ddf9b3e