### PR TITLE
Fix build output path

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 ## Building the React frontend
 
-The Electron application loads the compiled files from `frontend/dist`. If the
+The Electron application loads the compiled files from `frontend/build`. If the
 directory does not exist, build the frontend first:
 
 ```bash
 cd frontend
 npm install           # only needed once to install dependencies
-npm run build         # generates the `dist/` folder
+npm run build         # generates the `build/` folder
 ```
 
 The React entry component is `App.jsx`. Ensure this file exists and is used when
@@ -21,5 +21,6 @@ root:
 npm start
 ```
 
-The Vite configuration uses relative asset paths (`base: './'`) so the build
-works correctly when loaded via the `file://` protocol in Electron.
+The Create React App build uses relative asset paths thanks to the
+`"homepage": "./"` setting in `frontend/package.json`. This allows the build
+to load correctly when opened using the `file://` protocol in Electron.

--- a/main.js
+++ b/main.js
@@ -19,10 +19,10 @@ function createWindow() {
 
   const isDev = !app.isPackaged;
 
-  if (isDev) {
+    if (isDev) {
     win.loadURL('http://localhost:3000');
   } else {
-    win.loadFile(path.join(__dirname, 'frontend', 'dist', 'index.html'));
+    win.loadFile(path.join(__dirname, 'frontend', 'build', 'index.html'));
   }
 
   // Kill backend if window is closed directly


### PR DESCRIPTION
## Summary
- load CRA build from `frontend/build` in Electron
- update README instructions for the correct build folder

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c4b632470832799320a604e10d8e3